### PR TITLE
Update sub-package handling in the current recipe

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About aiida-core
-================
+About aiida
+===========
 
 Home: http://aiida.net
 
@@ -31,54 +31,55 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-aiida-green.svg)](https://anaconda.org/conda-forge/aiida) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/aiida.svg)](https://anaconda.org/conda-forge/aiida) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/aiida.svg)](https://anaconda.org/conda-forge/aiida) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/aiida.svg)](https://anaconda.org/conda-forge/aiida) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-aiida--core-green.svg)](https://anaconda.org/conda-forge/aiida-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/aiida-core.svg)](https://anaconda.org/conda-forge/aiida-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/aiida-core.svg)](https://anaconda.org/conda-forge/aiida-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/aiida-core.svg)](https://anaconda.org/conda-forge/aiida-core) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-aiida--core.services-green.svg)](https://anaconda.org/conda-forge/aiida-core.services) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/aiida-core.services.svg)](https://anaconda.org/conda-forge/aiida-core.services) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/aiida-core.services.svg)](https://anaconda.org/conda-forge/aiida-core.services) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/aiida-core.services.svg)](https://anaconda.org/conda-forge/aiida-core.services) |
 
-Installing aiida-core
-=====================
+Installing aiida
+================
 
-Installing `aiida-core` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `aiida` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `aiida-core, aiida-core.services` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `aiida, aiida-core, aiida-core.services` can be installed with `conda`:
 
 ```
-conda install aiida-core aiida-core.services
-```
-
-or with `mamba`:
-
-```
-mamba install aiida-core aiida-core.services
-```
-
-It is possible to list all of the versions of `aiida-core` available on your platform with `conda`:
-
-```
-conda search aiida-core --channel conda-forge
+conda install aiida aiida-core aiida-core.services
 ```
 
 or with `mamba`:
 
 ```
-mamba search aiida-core --channel conda-forge
+mamba install aiida aiida-core aiida-core.services
+```
+
+It is possible to list all of the versions of `aiida` available on your platform with `conda`:
+
+```
+conda search aiida --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search aiida --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search aiida-core --channel conda-forge
+mamba repoquery search aiida --channel conda-forge
 
-# List packages depending on `aiida-core`:
-mamba repoquery whoneeds aiida-core --channel conda-forge
+# List packages depending on `aiida`:
+mamba repoquery whoneeds aiida --channel conda-forge
 
-# List dependencies of `aiida-core`:
-mamba repoquery depends aiida-core --channel conda-forge
+# List dependencies of `aiida`:
+mamba repoquery depends aiida --channel conda-forge
 ```
 
 
@@ -123,17 +124,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating aiida-core-feedstock
-=============================
+Updating aiida-feedstock
+========================
 
-If you would like to improve the aiida-core recipe or build a new
+If you would like to improve the aiida recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/aiida-core-feedstock are
+Note that all branches in the conda-forge/aiida-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,82 +1,101 @@
-{% set name = "aiida-core" %}
+# version and build number
 {% set version = "2.0.1" %}
+{% set build = 1 %}
 
+# define the used meta and sub-package names
+{% set namemeta = "aiida" %}
+{% set namecore = "aiida-core" %}
+{% set nameservice = "aiida-core.services" %}
+
+# Toplevel meta-package
 package:
-  name: {{ name|lower }}
+  name: {{ namemeta|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ namecore[0] }}/{{ namecore }}/{{ namecore }}-{{ version }}.tar.gz
   sha256: 7b0a09bc02dee38410f6fc7dd0a679789bb60c0bcc2b75212e9668c727f6e966
 
 build:
-  number: 1
+  number: {{ build }}
   noarch: python
-  entry_points:
-    - verdi=aiida.cmdline.commands.cmd_verdi:verdi
-  script: 'python -m pip install . --no-deps --ignore-installed -vvv '
 
 requirements:
-  host:
-    - python
-    - pip
-    - flit-core
   run:
-    - python ~=3.8
-    - alembic ~=1.2
-    - archive-path ~=0.4.0
-    - aio-pika ~=6.6
-    - circus ~=0.17.1
-    - click-config-file ~=0.6.0
-    - click-spinner ~=0.1.8
-    - click ~=8.1
-    - disk-objectstore ~=0.6.0
-    - python-graphviz ~=0.13
-    - ipython ~=7.20
-    - jinja2 ~=3.0
-    - jsonschema ~=3.0
-    - kiwipy[rmq] ~=0.7.5
-    - importlib-metadata ~=4.3
-    - numpy ~=1.19
-    - pamqp ~=2.3
-    - paramiko ~=2.7,>=2.7.2
-    - plumpy ~=0.21.0
-    - pgsu ~=0.2.1
-    - psutil ~=5.6
-    - psycopg2-binary ~=2.8
-    - pytz ~=2021.1
-    - pyyaml ~=5.4
-    - sqlalchemy ~=1.4.22
-    - tabulate ~=0.8.5
-    - tqdm ~=4.45
-    - upf_to_json ~=0.9.2
-    - wrapt ~=1.11.1
-  run_constrained:
-    - aiida-core.services =={{ version }}
-
-test:
-  requires:
-    - pip
-  imports:
-    - aiida
-    - aiida.common
-    - aiida.common.hashing
-    - aiida.manage
-    - aiida.restapi
-    - aiida.schedulers
-    - aiida.transports
-    - aiida.tools
-    - aiida.tools.dbexporters
-    - aiida.tools.dbimporters
-  commands:
-    - verdi --help
-    - verdi --version
-    - pip check
+    - {{ namecore }} =={{ version }}
+    - {{ nameservice }} =={{ version }}
 
 outputs:
-  - name: aiida-core
-  - name: aiida-core.services
+  # subpackage aiida-core
+  - name: {{ namecore }}
     build:
+      number: {{ build }}
+      noarch: python
+      entry_points:
+        - verdi=aiida.cmdline.commands.cmd_verdi:verdi
+      script: 'python -m pip install . --no-deps --ignore-installed -vvv '
+
+    requirements:
+      host:
+        - python
+        - pip
+        - flit-core
+      run:
+        - python ~=3.8
+        - alembic ~=1.2
+        - archive-path ~=0.4.0
+        - aio-pika ~=6.6
+        - circus ~=0.17.1
+        - click-config-file ~=0.6.0
+        - click-spinner ~=0.1.8
+        - click ~=8.1
+        - disk-objectstore ~=0.6.0
+        - python-graphviz ~=0.13
+        - ipython ~=7.20
+        - jinja2 ~=3.0
+        - jsonschema ~=3.0
+        - kiwipy[rmq] ~=0.7.5
+        - importlib-metadata ~=4.3
+        - numpy ~=1.19
+        - pamqp ~=2.3
+        - paramiko ~=2.7,>=2.7.2
+        - plumpy ~=0.21.0
+        - pgsu ~=0.2.1
+        - psutil ~=5.6
+        - psycopg2-binary ~=2.8
+        - pytz ~=2021.1
+        - pyyaml ~=5.4
+        - sqlalchemy ~=1.4.22
+        - tabulate ~=0.8.5
+        - tqdm ~=4.45
+        - upf_to_json ~=0.9.2
+        - wrapt ~=1.11.1
+      run_constrained:
+        -  {{ nameservice}} =={{ version }}
+    
+    test:
+      requires:
+        - pip
+      imports:
+        - aiida
+        - aiida.common
+        - aiida.common.hashing
+        - aiida.manage
+        - aiida.restapi
+        - aiida.schedulers
+        - aiida.transports
+        - aiida.tools
+        - aiida.tools.dbexporters
+        - aiida.tools.dbimporters
+      commands:
+        - verdi --help
+        - verdi --version
+        - pip check
+    
+  # subpackage for aiida-core services
+  - name: {{ nameservice }}
+    build:
+      number: {{ build }}
       noarch: python
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,35 @@
-# version and build number
+# Set Version and Build-Number
 {% set version = "2.0.1" %}
 {% set build = 1 %}
 
-# define the used meta and sub-package names
-{% set namemeta = "aiida" %}
-{% set namecore = "aiida-core" %}
-{% set nameservice = "aiida-core.services" %}
+# Set names for the AiiDA Meta-Package and acompanying Sub-Packages
+{% set aiidameta = "aiida" %}
+{% set aiidacore = "aiida-core" %}
+{% set aiidaservice = "aiida-core.services" %}
 
-# Toplevel meta-package
+# Define the Source and AiiDA Meta-Package
 package:
-  name: {{ namemeta|lower }}
+  name: {{ aiidameta|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ namecore[0] }}/{{ namecore }}/{{ namecore }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ aiidacore[0] }}/{{ aiidacore }}/{{ aiidacore }}-{{ version }}.tar.gz
   sha256: 7b0a09bc02dee38410f6fc7dd0a679789bb60c0bcc2b75212e9668c727f6e966
 
 build:
   number: {{ build }}
   noarch: python
 
+# Packages that shall be shipped when installing from the Meta-Package are
+# defined here
 requirements:
   run:
-    - {{ namecore }} =={{ version }}
-    - {{ nameservice }} =={{ version }}
+    - {{ aiidacore }} =={{ version }}
+    - {{ aiidaservice }} =={{ version }}
 
+# Define the available Sub-Packages
 outputs:
-  # subpackage aiida-core
-  - name: {{ namecore }}
+  - name: {{ aiidacore }}
     build:
       number: {{ build }}
       noarch: python
@@ -71,7 +73,7 @@ outputs:
         - upf_to_json ~=0.9.2
         - wrapt ~=1.11.1
       run_constrained:
-        -  {{ nameservice}} =={{ version }}
+        -  {{ aiidaservice}} =={{ version }}
     
     test:
       requires:
@@ -92,8 +94,7 @@ outputs:
         - verdi --version
         - pip check
     
-  # subpackage for aiida-core services
-  - name: {{ nameservice }}
+  - name: {{ aiidaservice }}
     build:
       number: {{ build }}
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
         - upf_to_json ~=0.9.2
         - wrapt ~=1.11.1
       run_constrained:
-        -  {{ aiidaservice}} =={{ version }}
+        -  {{ aiidaservice }} =={{ version }}
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
 outputs:
   - name: {{ aiidacore }}
     build:
-      number: {{ build }}
       noarch: python
       entry_points:
         - verdi=aiida.cmdline.commands.cmd_verdi:verdi
@@ -96,7 +95,6 @@ outputs:
     
   - name: {{ aiidaservice }}
     build:
-      number: {{ build }}
       noarch: python
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Set Version and Build-Number
 {% set version = "2.0.1" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Set names for the AiiDA Meta-Package and acompanying Sub-Packages
 {% set aiidameta = "aiida" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.0.1" %}
 {% set build = 2 %}
 
-# Set names for the AiiDA Meta-Package and acompanying Sub-Packages
+# Set names for the AiiDA Meta-Package and accompanying Sub-Packages
 {% set aiidameta = "aiida" %}
 {% set aiidacore = "aiida-core" %}
 {% set aiidaservice = "aiida-core.services" %}
@@ -35,7 +35,6 @@ outputs:
       entry_points:
         - verdi=aiida.cmdline.commands.cmd_verdi:verdi
       script: 'python -m pip install . --no-deps --ignore-installed -vvv '
-
     requirements:
       host:
         - python
@@ -73,7 +72,6 @@ outputs:
         - wrapt ~=1.11.1
       run_constrained:
         -  {{ aiidaservice}} =={{ version }}
-    
     test:
       requires:
         - pip


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

As promised, here is the pull request with changes to the recipe which fixes #41

I'll give a brief explanation what changed and how this, as I believe, is intended to work now:

* ``aiida-core`` is now a proper sub-package, all dependencies, build-section, tests, etc. have been moved from the recipes top-level to the corresponding ``aiida-core`` outputs section
* the package name given in the recipe was renamed from ``aiida-core`` to simply ``aiida`` to remove the previous ambiguity which resulted in some spurious errors

With the changes above basically nothing would change, we would still have the two output packages ``aiida-core`` and ``aiida-core.services``. In that case, the given package name ``aiida`` would simply act as a dummy name. 

However, in this PR I also added the ``aiida-core`` and ``aiida-core.services`` sub-packages as explicit dependencies to the ``aiida`` top-level package. Doing so basically transforms the ``aiida`` dummy into an actual meta-package. In that case a third output package (i.e. ``aiida``) is generated. Installing from that package would then, of course, automatically install all packages that are defined as the dependencies (in the current state running ``conda install aiida`` would then install ``aiida-core`` and ``aiida-core.services`` in one go)

Let me know what you think about it!
