### PR TITLE
fix: relax rabbitmq-server upper bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Set Version and Build-Number
 {% set version = "2.1.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Set names for the AiiDA Meta-Package and accompanying Sub-Packages
 {% set aiidameta = "aiida" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,7 @@ outputs:
     requirements:
       run:
         - postgresql >=9.6
-        - rabbitmq-server >=3.7,<3.8.15
+        - rabbitmq-server >=3.7
     test:
       commands:
         - postgres --help


### PR DESCRIPTION
aiida-core and aiida-core.services could not be installed into the same environment because rabbitmq-server 3.8.14 requires openssl 1.1.1s, while python 3.8 seems to not like this version.

Also, rabbitmq 3.8 is end of life 07/22 [1]

[1] https://endoflife.date/rabbitmq

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
