### PR TITLE
fix: pin with `exact=False`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,6 +111,8 @@ outputs:
     build:
       noarch: python
     requirements:
+      host:
+        - python
       run:
         - {{ pin_subpackage(aiidacore) }}
         - ase ~=3.18
@@ -130,6 +132,8 @@ outputs:
     build:
       noarch: python
     requirements:
+      host:
+        - python
       run:
         - {{ pin_subpackage(aiidacore) }}
         - jupyter_client ~=6.1,<6.1.13
@@ -145,6 +149,8 @@ outputs:
     build:
       noarch: python
     requirements:
+      host:
+        - python
       run:
         - {{ pin_subpackage(aiidacore) }}
         - flask-cors ~=3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,7 @@ outputs:
     requirements:
       run:
         - postgresql >=9.6
-        - rabbitmq-server >=3.7
+        - rabbitmq-server >=3.7,<3.8.15
     test:
       commands:
         - postgres --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Set Version and Build-Number
 {% set version = "2.2.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Set names for the AiiDA Meta-Package and accompanying Sub-Packages
 {% set aiidameta = "aiida" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ build:
 # defined here
 requirements:
   run:
-    - {{ pin_subpackage(aiidacore, exact=True) }}
-    - {{ pin_subpackage(aiidaservice, exact=True) }}
+    - {{ pin_subpackage(aiidacore) }}
+    - {{ pin_subpackage(aiidaservice) }}
 
 # Define the available Sub-Packages
 outputs:
@@ -75,7 +75,7 @@ outputs:
         - werkzeug <2.2
         - wrapt ~=1.11
       run_constrained:
-        - {{ pin_subpackage(aiidaservice, exact=True) }}
+        - {{ pin_subpackage(aiidaservice) }}
     test:
       requires:
         - pip
@@ -112,7 +112,7 @@ outputs:
       noarch: python
     requirements:
       run:
-        - {{ pin_subpackage(aiidacore, exact=True) }}
+        - {{ pin_subpackage(aiidacore) }}
         - ase ~=3.18
         - matplotlib-base ~=3.3,>=3.3.4
         - pycifrw ~=4.4
@@ -131,7 +131,7 @@ outputs:
       noarch: python
     requirements:
       run:
-        - {{ pin_subpackage(aiidacore, exact=True) }}
+        - {{ pin_subpackage(aiidacore) }}
         - jupyter_client ~=6.1,<6.1.13
         - jupyter ~=1.0
         - notebook ~=6.1,>=6.1.5
@@ -146,7 +146,7 @@ outputs:
       noarch: python
     requirements:
       run:
-        - {{ pin_subpackage(aiidacore, exact=True) }}
+        - {{ pin_subpackage(aiidacore) }}
         - flask-cors ~=3.0
         - flask-restful ~=0.3.7
         - flask ~=2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,12 @@ build:
 # Packages that shall be shipped when installing from the Meta-Package are
 # defined here
 requirements:
+  # explicit python dependency required to obtain same build string
+  # as `aiida-core` package
+  host:
+    - python
   run:
-    - {{ pin_subpackage(aiidacore) }}
+    - {{ pin_subpackage(aiidacore, exact=True) }}
     - {{ pin_subpackage(aiidaservice) }}
 
 # Define the available Sub-Packages
@@ -114,7 +118,7 @@ outputs:
       host:
         - python
       run:
-        - {{ pin_subpackage(aiidacore) }}
+        - {{ pin_subpackage(aiidacore, exact=True) }}
         - ase ~=3.18
         - matplotlib-base ~=3.3,>=3.3.4
         - pycifrw ~=4.4
@@ -135,7 +139,7 @@ outputs:
       host:
         - python
       run:
-        - {{ pin_subpackage(aiidacore) }}
+        - {{ pin_subpackage(aiidacore, exact=True) }}
         - jupyter_client ~=6.1,<6.1.13
         - jupyter ~=1.0
         - notebook ~=6.1,>=6.1.5
@@ -152,7 +156,7 @@ outputs:
       host:
         - python
       run:
-        - {{ pin_subpackage(aiidacore) }}
+        - {{ pin_subpackage(aiidacore, exact=True) }}
         - flask-cors ~=3.0
         - flask-restful ~=0.3.7
         - flask ~=2.0


### PR DESCRIPTION
Pinning with `exact=True` requires the build strings of the packages to be identical. Looking at the package builds at

  https://anaconda.org/conda-forge/aiida-core/files
  https://anaconda.org/conda-forge/aiida-core.atomic_tools/files
  https://anaconda.org/conda-forge/aiida-core.services/files

we find that the build string of `aiida.core` and the other outputs differs.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
