### PR TITLE
Compatible release dependency on click

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Set Version and Build-Number
 {% set version = "2.7.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Set package metainfo
 {% set python_min = "3.9" %}
@@ -46,7 +46,7 @@ outputs:
         - asyncssh ~=2.19.0
         - circus ~=0.19.0
         - click-spinner ~=0.1.8
-        - click ~=8.1
+        - click ~=8.1.0
         - disk-objectstore ~=1.3.0
         - docstring_parser
         - get-annotations ~=0.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Hi,

In this [feedstock-update](https://github.com/conda-forge/aiida-fans-feedstock/pull/11),
the build seems to error out on checking the pip version constraints.
There, it is noted that since the pyproject.toml defines the constraint on click to be
```toml
'click~=8.1.0',
```
but in the recipe it is
´´´yaml
click ~=8.1
´´´,
conda-build installed ´click v8.2.1´, which fits the matchspec in the recipe, but not the one in the pyproject.toml.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
